### PR TITLE
Fixing case of public commands and help message indentation

### DIFF
--- a/webhook.py
+++ b/webhook.py
@@ -29,6 +29,13 @@ NO_IP_USER = os.environ['NO_IP_USER']
 NO_IP_PASSWORD = os.environ['NO_IP_PASSWORD']
 BASE_URL = f"https://api.telegram.org/bot{TOKEN}"
 
+def get_help_msg():
+    return '''/help - Brings up this help menu
+/startinstance - Starts/creates the minecraft ec2 instance and turns on the minecraft server
+/stopinstance - Stops the minecraft ec2 instance and turns off the minecraft server
+/getinstancestatus - Gets the current status of the instance (pending, stopping, stopped, etc.)
+/getinstanceip - Gets the public ip address of the instance in case you are having trouble connecting to No-Ip'''
+
 class InstanceState(IntEnum):
     pending = 0
     running = 16
@@ -56,14 +63,8 @@ def handler(event, context):
         elif message == "/start":
             send_telegram_message(chat_id, "Welcome to minebot!\n\nUse /help to see what I can do!")
         elif message == "/help":
-            send_telegram_message(chat_id,
-            '''/help - Brings up this help menu
-        /startInstance - Starts/creates the minecraft ec2 instance and turns on the minecraft server
-        /stopInstance - Stops the minecraft ec2 instance and turns off the minecraft server
-        /getInstanceStatus - Gets the current status of the instance (pending, stopping, stopped, etc.)
-        /getInstanceIP - Gets the public ip address of the instance in case you are having trouble connecting to No-Ip
-            ''')
-        elif message == "/startInstance":
+            send_telegram_message(chat_id, get_help_msg())
+        elif message == "/startinstance":
             if instance == None:
                 if key_pair_exists() and security_group_exists():
                     if create_instance():
@@ -80,7 +81,7 @@ def handler(event, context):
                         send_telegram_message(chat_id, "Successfully created new security group")
                     else:
                         send_telegram_message(chat_id, "Error creating security group")
-                    send_telegram_message(chat_id, "Please run 'startInstance' again")
+                    send_telegram_message(chat_id, "Please run '/startinstance' again")
             else:
                 if instance.state['Code'] == InstanceState.running:
                     send_telegram_message(chat_id, "Instance already running!")
@@ -98,17 +99,17 @@ def handler(event, context):
             else:
                 create_security_group()
                 send_telegram_message(chat_id, "Successfully created new security group")
-        elif message == "/getInstanceStatus":
+        elif message == "/getinstancestatus":
             if instance != None:
                 send_telegram_message(chat_id, f"The instance is currently: {instance.state['Name']}")
             else:
                 send_telegram_message(chat_id, "No instance exist. Start a new one first")
-        elif message == "/getInstanceIP":
+        elif message == "/getinstanceip":
             if instance != None and instance.state['Code'] == InstanceState.running:
                 send_telegram_message(chat_id, f"Instance Ip Address is: {instance.public_ip_address}")
             else:
                 send_telegram_message(chat_id, "No instance exist or instance is not running. Start a new/start instance first")
-        elif message == "/stopInstance":
+        elif message == "/stopinstance":
             if instance == None:
                 send_telegram_message(chat_id, "Instance does not exist! Nothing to stop!")
             else:


### PR DESCRIPTION
Telegram's autocomplete commands must be lower case, this makes all public commands follow this rule. Also fixes the python multi-line indentation issue