### PR TITLE
Add support for the /cmd command from Telegram

### DIFF
--- a/core/rcon.py
+++ b/core/rcon.py
@@ -1,18 +1,26 @@
+from dataclasses import dataclass
 from mcrcon import MCRcon
 import time
 
 HOST = "localhost"
-SECRET = "69420"
 
-def save_and_stop(wait_time_seconds = None):
-    with MCRcon(HOST, SECRET) as mcr:
-        if wait_time_seconds:
-            mcr.command(f"/tellraw @a {{\"text\":\"Server shutting down in {wait_time_seconds} seconds\",\"color\":\"#ff0000\"}}")
-            time.sleep(wait_time_seconds)
-        mcr.command('save-all')
-        mcr.command('stop')
+@dataclass
+class RCONClient:
+    host: str
+    secret: str
 
+    def __init__(self, host=HOST, secret=""):
+        self.host = host
+        self.secret = secret
 
-def send_command(command: str):
-    with MCRcon(HOST, SECRET) as mcr:
-        return mcr.command(command)
+    def save_and_stop(self, wait_time_seconds = None):
+        with MCRcon(self.host, self.secret) as mcr:
+            if wait_time_seconds:
+                mcr.command(f"/tellraw @a {{\"text\":\"Server shutting down in {wait_time_seconds} seconds\",\"color\":\"#ff0000\"}}")
+                time.sleep(wait_time_seconds)
+            mcr.command('save-all')
+            mcr.command('stop')
+
+    def send_command(self, command: str):
+        with MCRcon(self.host, self.secret) as mcr:
+            return mcr.command(command)


### PR DESCRIPTION
This PR adds support for sending Minecraft commands directly from Telegram

Usage:
- `/cmd <mc command>`

Examples
- `/cmd say Hello` 
- `/cmd give @a diamond`

Todo:
- The secret is still hard-coded, meaning anyone can access our server. We'll need to use ENV variables to security store it