### PR TITLE
Remove hard-coded RCON secret + loading from ENV

### DIFF
--- a/core/cron.py
+++ b/core/cron.py
@@ -7,7 +7,7 @@ from rcon import RCONClient
 
 import logging
 logger = logging.getLogger("cron")
-logging.basicConfig(level=logging.DEBUG)
+logging.basicConfig(level=logging.DEBUG, filename="log.txt")
 
 SECONDS_PER_MINUTE = 60
 CHECKS_TO_STOP = 2
@@ -16,8 +16,6 @@ CHECK_INTERVAL_SECONDS = 5 * SECONDS_PER_MINUTE
 
 SERVER_HOST = "localhost"
 SERVER_PORT = 25565
-
-RCON_SECRET = os.environ["MC_RCON_SECRET"]
 
 def stop_server(client: RCONClient):
     try:
@@ -38,6 +36,7 @@ def main():
         logger.info(f"Waiting {STARTUP_WAIT_SECONDS} seconds to let server start up...")
         time.sleep(STARTUP_WAIT_SECONDS)
         logger.info("Checker is now running...")
+        RCON_SECRET = os.environ["MC_RCON_SECRET"]
         client = RCONClient(secret=RCON_SECRET)
         server = MinecraftServer(SERVER_HOST, SERVER_PORT)
         while True:
@@ -57,10 +56,10 @@ def main():
                 logger.info("Empty server time exceeded, stopping server...")
                 stop_server(client)
                 break
-    except SystemExit as e:
+    except SystemExit:
         logger.info("Received SystemExit trap, stopping...")
-    except Exception as e:
-        logger.error(f"Error occurred while retriving status, stopping cron. Error: {e}")
+    except Exception:
+        logger.error(f"Error occurred while retriving status, stopping cron. Error: {traceback.format_exc()}")
         stop_server()
     finally:
         logger.info("Server stopped, exiting cron")

--- a/core/cron.py
+++ b/core/cron.py
@@ -1,6 +1,7 @@
 import time
 import traceback
 import signal
+import os
 from mcstatus import MinecraftServer
 from rcon import RCONClient
 
@@ -16,8 +17,7 @@ CHECK_INTERVAL_SECONDS = 5 * SECONDS_PER_MINUTE
 SERVER_HOST = "localhost"
 SERVER_PORT = 25565
 
-# TODO: read from server.properties file instead of hard-coding it
-RCON_SECRET = "69420"
+RCON_SECRET = os.environ["MC_RCON_SECRET"]
 
 def stop_server(client: RCONClient):
     try:

--- a/core/cron.py
+++ b/core/cron.py
@@ -27,6 +27,14 @@ def handle_kill_signal(sig_num, frame):
     logger.info(f"Received stop signal: {sig_num} ({signal.Signals(sig_num).name})")
     raise SystemExit(0)
 
+def get_rcon_secret():
+    secret = os.environ.get("MC_RCON_SECRET")
+    if secret != None:
+        return secret
+    
+    with open("rcon_secret.txt", "r") as f:
+        return f.read()
+
 def main():
     try:
         logger.info("Starting server checker cron...")
@@ -36,7 +44,7 @@ def main():
         logger.info(f"Waiting {STARTUP_WAIT_SECONDS} seconds to let server start up...")
         time.sleep(STARTUP_WAIT_SECONDS)
         logger.info("Checker is now running...")
-        RCON_SECRET = os.environ["MC_RCON_SECRET"]
+        RCON_SECRET = get_rcon_secret()
         client = RCONClient(secret=RCON_SECRET)
         server = MinecraftServer(SERVER_HOST, SERVER_PORT)
         while True:

--- a/scripts/init_server_settings.sh
+++ b/scripts/init_server_settings.sh
@@ -1,18 +1,18 @@
 # Sets up the minecraft server configs if not already setup
 EULA_FILE=eula.txt
 PROPERTIES_FILE=server.properties
+LOG_FILE=log.txt
 
 mkdir -p server
 
 if [ ! -f server/$EULA_FILE ]; then
-    echo "Creating an agreed EULA file..."
+    echo "Creating an agreed EULA file..." >> $LOG_FILE
     cp templates/${EULA_FILE} server
 fi
 
-
 if [ ! -f server/$PROPERTIES_FILE ]; then
-    echo "Creating a RCON-enabled server.properties file..."
+    echo "Creating a RCON-enabled server.properties file..." >> $LOG_FILE
     cp templates/${PROPERTIES_FILE} server
-    echo "Setting the RCON secret..."
+    echo "Setting the RCON secret..." >> $LOG_FILE
     python3 scripts/set_server_properties.py server/$PROPERTIES_FILE
 fi

--- a/scripts/init_server_settings.sh
+++ b/scripts/init_server_settings.sh
@@ -13,4 +13,6 @@ fi
 if [ ! -f server/$PROPERTIES_FILE ]; then
     echo "Creating a RCON-enabled server.properties file..."
     cp templates/${PROPERTIES_FILE} server
+    echo "Setting the RCON secret..."
+    python3 scripts/set_server_properties.py server/$PROPERTIES_FILE
 fi

--- a/scripts/properties_parser.py
+++ b/scripts/properties_parser.py
@@ -1,0 +1,38 @@
+from dataclasses import dataclass
+
+# Parser to read and modify Minecraft server.properties files
+@dataclass
+class PropertiesParser:
+    file_path: str
+    data: dict
+    def __init__(self, file_path: str):
+        self.file_path = file_path
+        self.data = dict()
+        with open(file_path, "r") as f:
+            for l in f:
+                line = l.strip()
+                
+                # Skip comments
+                if line.startswith("#"):
+                    continue
+                values = line.split("=")
+                if len(values) != 2:
+                    continue
+
+                prop, val = values
+                self.data[prop] = val
+    
+    # Gets the value of property
+    def get(self, prop: str):
+        return self.data.get(prop)
+    
+    # Sets property 'prop' to 'val'
+    def set(self, prop: str, val: str):
+        self.data[prop] = val
+
+    # Saves the data to the original file
+    # Comments are not saved since they're not important
+    def save(self):
+        with open(self.file_path, "w") as f:
+            for prop, val in self.data.items():
+                f.write(f"{prop}={val}\n")

--- a/scripts/properties_parser.py
+++ b/scripts/properties_parser.py
@@ -7,8 +7,19 @@ class PropertiesParser:
     data: dict
     def __init__(self, file_path: str):
         self.file_path = file_path
+        self.data = None
+    
+    # Gets the value of property
+    def get(self, prop: str):
+        return self.data.get(prop)
+    
+    # Sets property 'prop' to 'val'
+    def set(self, prop: str, val: str):
+        self.data[prop] = val
+
+    def __enter__(self):
         self.data = dict()
-        with open(file_path, "r") as f:
+        with open(self.file_path, "r") as f:
             for l in f:
                 line = l.strip()
                 
@@ -21,14 +32,11 @@ class PropertiesParser:
 
                 prop, val = values
                 self.data[prop] = val
-    
-    # Gets the value of property
-    def get(self, prop: str):
-        return self.data.get(prop)
-    
-    # Sets property 'prop' to 'val'
-    def set(self, prop: str, val: str):
-        self.data[prop] = val
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.save()
+        self.data = None
 
     # Saves the data to the original file
     # Comments are not saved since they're not important

--- a/scripts/set_server_properties.py
+++ b/scripts/set_server_properties.py
@@ -1,7 +1,7 @@
-import sys, os, logging
+import sys, os, logging, traceback
 
 logger = logging.getLogger("set_server_properties")
-logging.basicConfig(level=logging.DEBUG)
+logging.basicConfig(level=logging.DEBUG, filename="log.txt")
 
 from properties_parser import PropertiesParser
 
@@ -10,8 +10,11 @@ def run(properties_path: str):
     with PropertiesParser(properties_path) as props:
         props.set("enable-rcon", "true")
         props.set("rcon.password", RCON_SECRET)
-        
-    logger.info(f"Set RCON secret to '{RCON_SECRET}' at '{properties_path}'")
+
+    logger.info(f"Successfully set RCON to '{RCON_SECRET}' at '{properties_path}'")
 
 if __name__ == "__main__":
-    run(sys.argv[1])
+    try:
+        run(sys.argv[1])
+    except:
+        logger.error(f"Failed to set server properties: {traceback.format_exc()}")

--- a/scripts/set_server_properties.py
+++ b/scripts/set_server_properties.py
@@ -5,8 +5,16 @@ logging.basicConfig(level=logging.DEBUG, filename="log.txt")
 
 from properties_parser import PropertiesParser
 
+def get_rcon_secret():
+    secret = os.environ.get("MC_RCON_SECRET")
+    if secret != None:
+        return secret
+    
+    with open("rcon_secret.txt", "r") as f:
+        return f.read()
+
 def run(properties_path: str):
-    RCON_SECRET = os.environ["MC_RCON_SECRET"]
+    RCON_SECRET = get_rcon_secret()
     with PropertiesParser(properties_path) as props:
         props.set("enable-rcon", "true")
         props.set("rcon.password", RCON_SECRET)

--- a/scripts/set_server_properties.py
+++ b/scripts/set_server_properties.py
@@ -1,0 +1,18 @@
+import sys, os, logging
+
+logger = logging.getLogger("set_server_properties")
+logging.basicConfig(level=logging.DEBUG)
+
+from properties_parser import PropertiesParser
+
+def run(properties_path: str):
+    RCON_SECRET = os.environ["MC_RCON_SECRET"]
+    res = PropertiesParser(properties_path)
+
+    res.set("enable-rcon", "true")
+    res.set("rcon.password", RCON_SECRET)
+    res.save()
+    logger.info(f"Set RCON secret to '{RCON_SECRET}' at '{properties_path}'")
+
+if __name__ == "__main__":
+    run(sys.argv[1])

--- a/scripts/set_server_properties.py
+++ b/scripts/set_server_properties.py
@@ -7,11 +7,10 @@ from properties_parser import PropertiesParser
 
 def run(properties_path: str):
     RCON_SECRET = os.environ["MC_RCON_SECRET"]
-    res = PropertiesParser(properties_path)
-
-    res.set("enable-rcon", "true")
-    res.set("rcon.password", RCON_SECRET)
-    res.save()
+    with PropertiesParser(properties_path) as props:
+        props.set("enable-rcon", "true")
+        props.set("rcon.password", RCON_SECRET)
+        
     logger.info(f"Set RCON secret to '{RCON_SECRET}' at '{properties_path}'")
 
 if __name__ == "__main__":

--- a/templates/server.properties
+++ b/templates/server.properties
@@ -1,4 +1,3 @@
-#Minecraft server properties
 broadcast-rcon-to-ops=true
 view-distance=10
 enable-jmx-monitoring=false
@@ -9,7 +8,7 @@ gamemode=survival
 server-port=25565
 allow-nether=true
 enable-command-block=false
-enable-rcon=true
+enable-rcon=false
 sync-chunk-writes=true
 enable-query=false
 op-permission-level=4
@@ -17,7 +16,7 @@ prevent-proxy-connections=false
 resource-pack=
 entity-broadcast-range-percentage=100
 level-name=world
-rcon.password=69420
+rcon.password=
 player-idle-timeout=0
 motd=A Minecraft Server
 query.port=25565

--- a/webhook.py
+++ b/webhook.py
@@ -10,14 +10,7 @@ import os
 import requests
 import traceback
 from enum import IntEnum
-
 from core.rcon import RCONClient
-
-try:
-    TOKEN = os.environ['TELEGRAM_TOKEN']
-except:
-    logger.error(f"Failed to get telegram token from env, is it set? Error: {traceback.format_exc()}")
-    TOKEN = ""
 
 ec2 = boto3.resource('ec2')
 
@@ -30,6 +23,7 @@ NO_IP_PASSWORD = os.environ['NO_IP_PASSWORD']
 MC_SERVER_URL = os.environ["MC_SERVER_URL"]
 MC_RCON_SECRET = os.environ["MC_RCON_SECRET"]
 BOT_URL = f"https://api.telegram.org/bot{TOKEN}"
+
 def get_help_msg():
     return '''/help - Brings up this help menu
 /startinstance - Starts/creates the minecraft ec2 instance and turns on the minecraft server
@@ -269,6 +263,9 @@ def create_instance():
 
                             yum install -y git\n
                             git clone https://github.com/Cypheruim/minebot.git\n
+
+                            echo "Exporting RCON secret '{MC_RCON_SECRET}' to env"\n
+                            export MC_RCON_SECRET={MC_RCON_SECRET}\n
 
                             cp /minebot/minebot-startup.service /etc/systemd/system/\n
                             chmod +x /minebot/start.sh\n

--- a/webhook.py
+++ b/webhook.py
@@ -265,7 +265,9 @@ def create_instance():
                             git clone https://github.com/Cypheruim/minebot.git\n
 
                             echo "Exporting RCON secret '{MC_RCON_SECRET}' to env"\n
-                            echo "export MC_RCON_SECRET={MC_RCON_SECRET}" >> /home/ec2-user/.bashrc\n
+                            echo "export MC_RCON_SECRET={MC_RCON_SECRET}" >> ~/.bashrc\n
+                            echo "Exporting RCON secret '{MC_RCON_SECRET}' to rcon_secret.txt"\n
+                            echo -n {MC_RCON_SECRET} > /minebot/rcon_secret.txt
 
                             cp /minebot/minebot-startup.service /etc/systemd/system/\n
                             chmod +x /minebot/start.sh\n

--- a/webhook.py
+++ b/webhook.py
@@ -265,7 +265,7 @@ def create_instance():
                             git clone https://github.com/Cypheruim/minebot.git\n
 
                             echo "Exporting RCON secret '{MC_RCON_SECRET}' to env"\n
-                            export MC_RCON_SECRET={MC_RCON_SECRET}\n
+                            echo "export MC_RCON_SECRET={MC_RCON_SECRET}" >> /home/ec2-user/.bashrc\n
 
                             cp /minebot/minebot-startup.service /etc/systemd/system/\n
                             chmod +x /minebot/start.sh\n


### PR DESCRIPTION
This addresses the hard-coded RCON secret issue by instead dynamically inject the pre-set secret defined by Lamba during instance creation. The steps are as follow:
1. The webhook Lambda handler will have environment variable `MC_RCON_SECRET` storing the secret
2. When creating a new instance, lambda will set the secret as an env variable in the instance
3. When the server is being created the first time, a custom parser is used to parse the `server.properties` file and set the secret from the env variable

Note:
- To reset the secret, the instance must be terminated